### PR TITLE
fix #69

### DIFF
--- a/py17track/package.py
+++ b/py17track/package.py
@@ -239,9 +239,11 @@ COUNTRY_MAP: Dict[int, str] = {
 
 PACKAGE_STATUS_MAP: Dict[int, str] = {
     0: "Not Found",
+    5: "Unknown",
     10: "In Transit",
     20: "Expired",
     30: "Ready to be Picked Up",
+    32: "Unknown",
     35: "Undelivered",
     40: "Delivered",
     50: "Returned",


### PR DESCRIPTION
**Describe what the PR does:**

Fixes strange new states that are returned 5 and 32 that are not covered currenty, thus causing an exception.
The website also doesn't know the meaning of those states (see screenshot in issue)

**Does this fix a specific issue?**

Fixes https://github.com/bachya/py17track/issues/69
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
